### PR TITLE
Add IntervalAnnouncements

### DIFF
--- a/src/main/kotlin/dev/civmc/bumhug/hacks/IntervalAnnouncement.kt
+++ b/src/main/kotlin/dev/civmc/bumhug/hacks/IntervalAnnouncement.kt
@@ -1,0 +1,103 @@
+package dev.civmc.bumhug.hacks
+
+import dev.civmc.bumhug.Bumhug
+import dev.civmc.bumhug.Hack
+import org.bukkit.Bukkit
+import org.bukkit.ChatColor
+import java.time.LocalDateTime
+import java.util.logging.Level
+import kotlin.math.roundToLong
+
+class IntervalAnnouncement: Hack() {
+    override val configName = "intervalAnnouncement"
+    override val prettyName = "Interval Announcements"
+
+    val HOURS_PER_DAY = 24
+    val MINUTES_PER_HOUR = 60
+    val SECONDS_PER_MINUTE = 60
+
+    var announcements = HashSet<Announcement>()
+
+    class Announcement(
+            /**
+             * The key of the announcement in the config
+             */
+            val key: String,
+
+            /**
+             * How often, in seconds, the announcement should be made
+             */
+            val interval: Long,
+
+            /**
+             * The content of the announcement
+             */
+            val message: String,
+
+            /**
+             * The permission the announcement should be broadcasted to
+             */
+            val permission: String,
+
+            /**
+             * The last time the announcement was made.
+             */
+            var lastAnnouncementTime: LocalDateTime
+    )
+
+    init {
+        // parse all the announcements from the config
+        for (section in config.getConfigurationSection("announcements").getValues(false)) {
+            val key = section.key;
+
+            val configSection = config.getConfigurationSection(key)
+
+            val message = ChatColor.translateAlternateColorCodes('&', configSection.getString("message"))
+            val permission = configSection.getString("permission", "bumhug.intervalannouncement.everyone");
+
+            val intervalDays = configSection.getDouble("intervalDays", 0.0)
+            val intervalHours = configSection.getDouble("intervalHours", 0.0)
+            val intervalMinutes = configSection.getDouble("intervalMinutes", 0.0)
+            val intervalSeconds = configSection.getDouble("intervalSeconds", 0.0)
+
+            if (intervalDays == 0.0 &&
+                    intervalHours == 0.0 &&
+                    intervalMinutes == 0.0 &&
+                    intervalSeconds == 0.0) {
+                Bumhug.instance!!.logger.log(Level.WARNING,
+                        "all intervals of interval message '$key' are 0, skipping")
+            }
+
+            val seconds = intervalSeconds +
+                    intervalMinutes * SECONDS_PER_MINUTE +
+                    intervalHours * MINUTES_PER_HOUR * SECONDS_PER_MINUTE +
+                    intervalDays * HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MINUTE
+
+            announcements.add(Announcement(
+                    key = key,
+                    interval = seconds.roundToLong(),
+                    message = message,
+                    permission = permission,
+                    lastAnnouncementTime = LocalDateTime.now()
+            ))
+        }
+
+        // start the tack to make the announcements
+        Bukkit.getScheduler().scheduleSyncRepeatingTask(Bumhug.instance!!, this::makeAnnouncementsAsNeeded, 1, 20)
+    }
+
+    /**
+     * Scans over the announcements set, and if any of the announcements are due to be made, makes those announcements.
+     */
+    fun makeAnnouncementsAsNeeded() {
+        for (announcement in announcements) {
+            // if the announcement is due to be made
+            if (announcement.lastAnnouncementTime
+                            .plusSeconds(announcement.interval)
+                            .isBefore(LocalDateTime.now())) {
+                // make the announcement
+                Bukkit.broadcast(announcement.message, announcement.permission)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/civmc/bumhug/hacks/IntervalAnnouncement.kt
+++ b/src/main/kotlin/dev/civmc/bumhug/hacks/IntervalAnnouncement.kt
@@ -18,7 +18,7 @@ class IntervalAnnouncement: Hack() {
 
     var announcements = HashSet<Announcement>()
 
-    class Announcement(
+    data class Announcement(
             /**
              * The key of the announcement in the config
              */

--- a/src/main/kotlin/dev/civmc/bumhug/hacks/IntervalAnnouncement.kt
+++ b/src/main/kotlin/dev/civmc/bumhug/hacks/IntervalAnnouncement.kt
@@ -97,6 +97,9 @@ class IntervalAnnouncement: Hack() {
                             .isBefore(LocalDateTime.now())) {
                 // make the announcement
                 Bukkit.broadcast(announcement.message, announcement.permission)
+
+                // update time
+                announcement.lastAnnouncementTime = LocalDateTime.now()
             }
         }
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,4 +42,26 @@ newfriendAssist:
     bed:
       material: BED
       amount: 1
-    
+intervalAnnouncement:
+  enabled: true
+  announcements:
+    hourlymessage:
+      message: hourly message
+      intervalHours: 1
+    discord:
+      message: Join our discord at http://discord.gg/XXXXXXX
+      intervalHours: 0.5 # You could also say this as intervalMinutes: 30
+    patreon:
+      message: Join our patreon at http://patreon.com/XXXXXX
+      intervalMinutes: 25
+     #permission: patreon.notsubscribed # commented out since the permission doesn't exist
+    completeformat:
+      intervalDays: 0.05
+      intervalHours: 3
+      intervalMinutes: 2
+      intervalSeconds: 100
+      # All of these can be used at once, as they're converted to seconds and summed up.
+      # Fractional seconds will be ignored.
+      message: "&5Color codes can also be used, but need to be in quotes if they start with an ampersand"
+      permission: bumhug.intervalannouncement.everyone
+      # Can be any permission. This one is the default, and anyone with the permission will receive that announcement.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -28,6 +28,9 @@ permissions:
   bumhug.ping.other:
     description: Get another player's ping
     default: op
+  bumhug.intervalannouncement.everyone:
+    description: Used to send an interval message to everyone when another permission isn't provided
+    default: true
 commands:
   reloadinventoy:
     description: Reload a player's inventoy from before the last time they died


### PR DESCRIPTION
These announcements should run somewhat on time, as it's entirely based in clock time, with ticks only being used to check if there is an announcement once per 20 ticks. Thus, if the TPS is 1, the announcements should at most be 20 seconds off of the interval described in the config.

In the future, we can support the ~~horrible~~ fancy new JSON chat format minecraft has going on to get hover text and buttons to click, but I really do not want to be the person to try to implement a sane YAML-based format for that.

Closes #19 