### PR TITLE
Make players drop all exp on death

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -140,9 +140,13 @@
     <dependency>
       <groupId>vg.civcraft.mc.civmodcore</groupId>
       <artifactId>CivModCore</artifactId>
-      <version>1.6.1</version>
+      <version>1.6.0</version>
       <scope>provided</scope>
       <exclusions>
+        <exclusion>
+          <artifactId>metrics</artifactId>
+          <groupId>org.mcstats.bukkit</groupId>
+        </exclusion>
         <exclusion>
           <artifactId>HikariCP</artifactId>
           <groupId>com.zaxxer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,18 @@
         </exclusion>
       </exclusions>
     </dependency>
-      <dependency>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-reflect</artifactId>
-          <version>RELEASE</version>
-          <scope>compile</scope>
-      </dependency>
+    <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-reflect</artifactId>
+        <version>RELEASE</version>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>vg.civcraft.mc.civmodcore</groupId>
+        <artifactId>CivModCore</artifactId>
+        <version>1.6.0</version>
+        <scope>provided</scope>
+    </dependency>
   </dependencies>
   <repositories>
       <repository>

--- a/src/main/kotlin/dev/civmc/bumhug/hacks/BottledExp.kt
+++ b/src/main/kotlin/dev/civmc/bumhug/hacks/BottledExp.kt
@@ -1,0 +1,140 @@
+package dev.civmc.bumhug.hacks
+
+import dev.civmc.bumhug.Bumhug
+import dev.civmc.bumhug.Hack
+import org.bukkit.event.Listener
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.ExpBottleEvent
+import org.bukkit.event.EventPriority
+import org.bukkit.ChatColor
+import org.bukkit.Material
+import org.bukkit.event.EventHandler
+import org.bukkit.event.block.Action
+import vg.civcraft.mc.civmodcore.itemHandling.ItemMap
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.inventory.ItemStack
+import java.util.logging.Level
+
+class BottledExp: Hack(), Listener {
+    override val configName = "bottledExp"
+    override val prettyName = "Bottled Experince"
+
+    val expPerBottle = config.getInt("expPerBottle")
+
+    @EventHandler
+    fun playerInteract(event: PlayerInteractEvent) {
+        if (event.action != Action.LEFT_CLICK_BLOCK
+                || event.clickedBlock == null
+                || event.clickedBlock.type !== Material.ENCHANTMENT_TABLE)
+            return
+
+        val totalExperience = computeCurrentEXP(event.player)
+
+        if (event.player.inventory.itemInMainHand == null ||
+                event.player.inventory.itemInMainHand.type != Material.GLASS_BOTTLE ||
+                totalExperience < expPerBottle)
+            return
+
+        createEXPBottles(event.player, totalExperience)
+    }
+
+    private fun createEXPBottles(player: Player, totalExperience: Int) {
+        val numberOfBottles = ItemMap(player.inventory).getAmount(ItemStack(Material.GLASS_BOTTLE))
+        val expAvailable = totalExperience / expPerBottle
+        val bottlesToRemove = Math.min(numberOfBottles, expAvailable)
+
+        Bumhug.instance!!.logger.log(Level.INFO,
+                "${player.name} interacted with enchanting table, " +
+                        "inventory has $numberOfBottles bottles, $totalExperience total experience, " +
+                        "enough to fill $bottlesToRemove bottles")
+
+        if (bottlesToRemove == 0) {
+            return
+        }
+
+        var noSpace = false
+        var expBottleCount = 0
+        val removeMap = ItemMap()
+
+        removeMap.addItemAmount(ItemStack(Material.GLASS_BOTTLE), bottlesToRemove)
+
+        for (item in removeMap.itemStackRepresentation) {
+            val initialAmount = item.amount
+
+            player.inventory.removeItem(item)
+            item.type = Material.EXP_BOTTLE
+
+            val result = player.inventory.addItem(item)
+
+            if (result != null && result.size > 0) {
+                item.type = Material.GLASS_BOTTLE
+                player.inventory.addItem(item)
+
+                noSpace = true
+
+                Bumhug.instance!!.logger.log(Level.INFO, "Cannot store ${item.amount} " +
+                        "exp bottles in inventory for ${player.name}")
+
+                break
+            } else {
+                expBottleCount += initialAmount
+
+                Bumhug.instance!!.logger.log(Level.INFO, "Turned $initialAmount " +
+                        "bottles into exp bottles for ${player.name}")
+            }
+        }
+
+        if (expBottleCount > 0) {
+            val endEXP = totalExperience - expBottleCount * expPerBottle
+
+            Bumhug.instance!!.logger.log(Level.INFO, "Set exp for " + player.name + " to " + endEXP)
+
+            player.level = 0
+            player.exp = 0f
+            player.giveExp(endEXP)
+
+            player.sendMessage("${ChatColor.GREEN}Created $expBottleCount EXP bottles.")
+        }
+
+        if (noSpace) {
+            player.sendMessage("${ChatColor.RED}Not enough space in inventory for all EXP bottles.")
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    fun expBottleEvent(event: ExpBottleEvent) {
+        event.experience = expPerBottle
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    fun expBottleEventMonitor(event: ExpBottleEvent) {
+        if (event.experience != expPerBottle) {
+            Bumhug.instance!!.logger.log(Level.INFO, "Xp control lost: ${event.experience}")
+        }
+    }
+
+    fun computeCurrentEXP(player: Player): Int {
+        // good luck
+        val cLevel = player.level.toFloat()
+        val progress = player.exp
+        var a = 1f
+        var b = 6f
+        var c = 0f
+        var x = 2f
+        var y = 7f
+        if (cLevel > 16 && cLevel <= 31) {
+            a = 2.5f
+            b = -40.5f
+            c = 360f
+            x = 5f
+            y = -38f
+        } else if (cLevel >= 32) {
+            a = 4.5f
+            b = -162.5f
+            c = 2220f
+            x = 9f
+            y = -158f
+        }
+        return Math.floor((a * cLevel * cLevel + b * cLevel + c + progress * (x * cLevel + y)).toDouble()).toInt()
+    }
+}

--- a/src/main/kotlin/dev/civmc/bumhug/hacks/BottledExp.kt
+++ b/src/main/kotlin/dev/civmc/bumhug/hacks/BottledExp.kt
@@ -2,6 +2,7 @@ package dev.civmc.bumhug.hacks
 
 import dev.civmc.bumhug.Bumhug
 import dev.civmc.bumhug.Hack
+import dev.civmc.bumhug.util.levelExpToPoints
 import org.bukkit.event.Listener
 import org.bukkit.entity.Player
 import org.bukkit.event.entity.ExpBottleEvent
@@ -28,7 +29,7 @@ class BottledExp: Hack(), Listener {
                 || event.clickedBlock.type !== Material.ENCHANTMENT_TABLE)
             return
 
-        val totalExperience = computeCurrentEXP(event.player)
+        val totalExperience = levelExpToPoints(event.player.level, event.player.exp)
 
         if (event.player.inventory.itemInMainHand == null ||
                 event.player.inventory.itemInMainHand.type != Material.GLASS_BOTTLE ||
@@ -111,30 +112,5 @@ class BottledExp: Hack(), Listener {
         if (event.experience != expPerBottle) {
             Bumhug.instance!!.logger.log(Level.INFO, "Xp control lost: ${event.experience}")
         }
-    }
-
-    fun computeCurrentEXP(player: Player): Int {
-        // good luck
-        val cLevel = player.level.toFloat()
-        val progress = player.exp
-        var a = 1f
-        var b = 6f
-        var c = 0f
-        var x = 2f
-        var y = 7f
-        if (cLevel > 16 && cLevel <= 31) {
-            a = 2.5f
-            b = -40.5f
-            c = 360f
-            x = 5f
-            y = -38f
-        } else if (cLevel >= 32) {
-            a = 4.5f
-            b = -162.5f
-            c = 2220f
-            x = 9f
-            y = -158f
-        }
-        return Math.floor((a * cLevel * cLevel + b * cLevel + c + progress * (x * cLevel + y)).toDouble()).toInt()
     }
 }

--- a/src/main/kotlin/dev/civmc/bumhug/hacks/GameFixes.kt
+++ b/src/main/kotlin/dev/civmc/bumhug/hacks/GameFixes.kt
@@ -1,6 +1,7 @@
 package dev.civmc.bumhug.hacks
 
 import dev.civmc.bumhug.Hack
+import dev.civmc.bumhug.util.levelExpToPoints
 import dev.civmc.bumhug.util.tryToTeleportVertically
 import org.bukkit.GameMode
 import org.bukkit.Material
@@ -12,6 +13,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.EntityPortalEvent
 import org.bukkit.event.entity.EntityTeleportEvent
+import org.bukkit.event.entity.PlayerDeathEvent
 import org.bukkit.event.player.PlayerMoveEvent
 import org.bukkit.inventory.InventoryHolder
 
@@ -22,6 +24,8 @@ public class GameFixes: Hack(), Listener {
 	private val preventStorageTeleport = config.getBoolean("preventStorageTeleport")
 	private val preventBedBombing = config.getBoolean("preventBedBombing")
 	private val preventFallingThroughBedrock = config.getBoolean("preventFallingThroughBedrock")
+	private val dropAllExpOnDeath = config.getBoolean("dropAllExpOnDeath")
+	private val deathExpPenalty = config.getDouble("deathExpPenalty")
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	fun onStorageTeleport(event: EntityTeleportEvent) {
@@ -67,5 +71,13 @@ public class GameFixes: Hack(), Listener {
 
 			tryToTeleportVertically(event.player, event.to, "falling into the void")
 		}
+	}
+
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	fun onPlayerDeath(event: PlayerDeathEvent){
+		if (!dropAllExpOnDeath)
+			return
+
+		event.droppedExp = (levelExpToPoints(event.entity.level, event.entity.exp) * deathExpPenalty).toInt()
 	}
 }

--- a/src/main/kotlin/dev/civmc/bumhug/util/ExpMath.kt
+++ b/src/main/kotlin/dev/civmc/bumhug/util/ExpMath.kt
@@ -1,0 +1,24 @@
+package dev.civmc.bumhug.util
+
+fun levelExpToPoints(level: Int, exp: Float): Int {
+    // good luck
+    var a = 1f
+    var b = 6f
+    var c = 0f
+    var x = 2f
+    var y = 7f
+    if (level > 16 && level <= 31) {
+        a = 2.5f
+        b = -40.5f
+        c = 360f
+        x = 5f
+        y = -38f
+    } else if (level >= 32) {
+        a = 4.5f
+        b = -162.5f
+        c = 2220f
+        x = 9f
+        y = -158f
+    }
+    return Math.floor((a * level * level + b * level + c + exp * (x * level + y)).toDouble()).toInt()
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -65,3 +65,6 @@ intervalAnnouncement:
       message: "&5Color codes can also be used, but need to be in quotes if they start with an ampersand"
       permission: bumhug.intervalannouncement.everyone
       # Can be any permission. This one is the default, and anyone with the permission will receive that announcement.
+bottledExp:
+  enabled: true
+  expPerBottle: 10

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,8 @@ gameFeatures:
   enderChestPlacement: true
   disableElytraFirework: true
   preventFallingThroughBedrock: true
+  dropAllExpOnDeath: true
+  deathExpPenalty: 0.9 # drop 90% of exp on death. From 0.0 to drop no exp to 1.0 to drop all exp. exp not dropped is deleted
 ctAnnounce:
   enabled: true
   delay: 10000


### PR DESCRIPTION
Based on #26, that one should be merged first since it adds some exp math.

Players will now drop all of their exp on death, or configurably some percentage of their Exp (default 90%). The rest of their exp will be deleted.